### PR TITLE
Platform independent updates!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
 .gradle
+.idea/

--- a/src/main/java/com/briksoftware/updatefx/core/UpdateDownloadService.java
+++ b/src/main/java/com/briksoftware/updatefx/core/UpdateDownloadService.java
@@ -54,7 +54,7 @@ public class UpdateDownloadService extends Service<Path> {
                 Binary toDownload = null;
 
                 for (Binary binary : release.getBinaries()) {
-                    if (isCurrentPlatform(binary.getPlatform()) || binary.getPlatform() == Platform.independent) {
+                    if (isCurrentPlatform(binary.getPlatform())) {
                         toDownload = binary;
                         break;
                     }

--- a/src/main/java/com/briksoftware/updatefx/core/UpdateDownloadService.java
+++ b/src/main/java/com/briksoftware/updatefx/core/UpdateDownloadService.java
@@ -40,89 +40,93 @@ import com.briksoftware.updatefx.model.Platform;
 import com.briksoftware.updatefx.model.Release;
 
 public class UpdateDownloadService extends Service<Path> {
-	private Release release;
+    private Release release;
 
-	public UpdateDownloadService(Release release) {
-		this.release = release;
-	}
+    public UpdateDownloadService(Release release) {
+        this.release = release;
+    }
 
-	@Override
-	protected Task<Path> createTask() {
-		return new Task<Path>() {
-			@Override
-			protected Path call() throws Exception {
-				Binary toDownload = null;
+    @Override
+    protected Task<Path> createTask() {
+        return new Task<Path>() {
+            @Override
+            protected Path call() throws Exception {
+                Binary toDownload = null;
 
-				for (Binary binary : release.getBinaries()) {
-					if (isCurrentPlatform(binary.getPlatform()) || binary.getPlatform() == Platform.independent) {
-						toDownload = binary;
-						break;
-					}
-				}
+                for (Binary binary : release.getBinaries()) {
+                    if (isCurrentPlatform(binary.getPlatform()) || binary.getPlatform() == Platform.independent) {
+                        toDownload = binary;
+                        break;
+                    }
+                }
 
-				if (toDownload == null) {
-					throw new IllegalArgumentException("This release does not contain binaries for this platform");
-				}
+                if (toDownload == null) {
+                    throw new IllegalArgumentException("This release does not contain binaries for this platform");
+                }
 
-				URL fileURL = toDownload.getHref();
-				URLConnection connection = fileURL.openConnection();
-				connection.connect();
+                URL fileURL = toDownload.getHref();
+                URLConnection connection = fileURL.openConnection();
+                connection.connect();
 
-				long len = connection.getContentLengthLong();
+                long len = connection.getContentLengthLong();
 
-				if (len == -1) {
-					len = toDownload.getSize();
-				}
+                if (len == -1) {
+                    len = toDownload.getSize();
+                }
 
-				updateProgress(0, len);
+                updateProgress(0, len);
 
-				String fileName = connection.getHeaderField("Content-Disposition");
-				if (fileName != null && fileName.contains("=")) {
-					fileName = fileName.split("=")[1];
-				} else {
-					String url = toDownload.getHref().getPath();
-					int lastSlashIdx = url.lastIndexOf('/');
-					
-					if (lastSlashIdx >= 0) {						
-						fileName = url.substring(lastSlashIdx + 1, url.length());
-					} else {
-						fileName = url;
-					}
-				}
+                String fileName = connection.getHeaderField("Content-Disposition");
+                if (fileName != null && fileName.contains("=")) {
+                    fileName = fileName.split("=")[1];
+                } else {
+                    String url = toDownload.getHref().getPath();
+                    int lastSlashIdx = url.lastIndexOf('/');
 
-				Path downloadFile = Paths.get(System.getProperty("java.io.tmpdir"), fileName);
-				
-				try(OutputStream fos = Files.newOutputStream(downloadFile, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE); 
-						BufferedInputStream is = new BufferedInputStream(connection.getInputStream())) {
-					byte[] buffer = new byte[512];
-					int n;
-					long totalDownload = 0;
-					
-					while ((n = is.read(buffer)) != -1) {
-						fos.write(buffer, 0, n);
-						totalDownload += n;
-						updateProgress(totalDownload, len);
-					}
-				}
-				
-				return downloadFile;
-			}
-		};
-	}
+                    if (lastSlashIdx >= 0) {
+                        fileName = url.substring(lastSlashIdx + 1, url.length());
+                    } else {
+                        fileName = url;
+                    }
+                }
 
-	private boolean isCurrentPlatform(Platform platform) {
-		String currentPlatform = System.getProperty("os.name").toLowerCase();
+                Path downloadFile = Paths.get(System.getProperty("java.io.tmpdir"), fileName);
 
-		if (currentPlatform.startsWith("mac")) {
-			return platform == Platform.mac;
-		} else if (currentPlatform.startsWith("windows")) {
-			if (System.getProperty("os.arch").contains("64")) {
-				return platform == Platform.win_x64;
-			} else {
-				return platform == Platform.win_x86;
-			}
-		} else {
-			throw new IllegalStateException("UpdateFX does not support this platform");
-		}
-	}
+                try (OutputStream fos = Files.newOutputStream(downloadFile, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
+                     BufferedInputStream is = new BufferedInputStream(connection.getInputStream())) {
+                    byte[] buffer = new byte[512];
+                    int n;
+                    long totalDownload = 0;
+
+                    while ((n = is.read(buffer)) != -1) {
+                        fos.write(buffer, 0, n);
+                        totalDownload += n;
+                        updateProgress(totalDownload, len);
+                    }
+                }
+
+                return downloadFile;
+            }
+        };
+    }
+
+    private boolean isCurrentPlatform(Platform platform) {
+        if (platform == Platform.independent) {
+            return true;
+        }
+
+        String currentPlatform = System.getProperty("os.name").toLowerCase();
+
+        if (currentPlatform.startsWith("mac")) {
+            return platform == Platform.mac;
+        } else if (currentPlatform.startsWith("windows")) {
+            if (System.getProperty("os.arch").contains("64")) {
+                return platform == Platform.win_x64;
+            } else {
+                return platform == Platform.win_x86;
+            }
+        } else {
+            throw new IllegalStateException("UpdateFX does not support this platform unless application is platform independent");
+        }
+    }
 }

--- a/src/main/java/com/briksoftware/updatefx/core/UpdateDownloadService.java
+++ b/src/main/java/com/briksoftware/updatefx/core/UpdateDownloadService.java
@@ -54,7 +54,7 @@ public class UpdateDownloadService extends Service<Path> {
 				Binary toDownload = null;
 
 				for (Binary binary : release.getBinaries()) {
-					if (isCurrentPlatform(binary.getPlatform())) {
+					if (isCurrentPlatform(binary.getPlatform()) || binary.getPlatform() == Platform.independent) {
 						toDownload = binary;
 						break;
 					}

--- a/src/main/java/com/briksoftware/updatefx/model/Platform.java
+++ b/src/main/java/com/briksoftware/updatefx/model/Platform.java
@@ -31,5 +31,6 @@ import javax.xml.bind.annotation.XmlType;
 public enum Platform {
 	mac,
 	win_x86,
-	win_x64
+	win_x64,
+	independent
 }


### PR DESCRIPTION
If a binary is marked as independent, it will download for any platform. This is tested on windows x64, and linux Ubuntu 16.04. We also tested on mac OSX El Capitan, running the same SDK version as the linux install that worked, but the mac failed to recognise that there were updates available. 

UpdateDownloadService.java has largely changed because of an auto-format, but this is only the layout of the code. I only added the if statement at the top of the method: isCurrentPlatform, and also the Platform.independent enum entry.

I also ignored .idea/ so that no pointless IDE files are synced into the repo.
